### PR TITLE
Avoid NodeJS exception

### DIFF
--- a/.changeset/eight-chicken-shout.md
+++ b/.changeset/eight-chicken-shout.md
@@ -1,0 +1,5 @@
+---
+'@simconnect.js/api': patch
+---
+
+Change throw error to use the onException callback to avoid an unhandle promise rejection.


### PR DESCRIPTION
Change throw error to use the onException callback to avoid an unhandle promise rejection.